### PR TITLE
CCM-30: Added correct consent category to video iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All Notable changes to **Digipolis DG Cookiebot** module.
 
 ### Added
 
-* Added the [COOKIEBOT_DECLARATION] placeholder filter.
+* CCM-39: Added the [COOKIEBOT_DECLARATION] placeholder filter.
+* CCM-30: Added the proper data-cookieconsent level to video_embed_field when
+  the privacy option is enabled.
 
 [8.x-1.0-alpha1]: https://github.com/digipolisgent/drupal_module_dg-cookiebot/releases/tag/8.x-1.0-alpha1
 [Unreleased]: https://github.com/digipolisgent/drupal_module_dg-cookiebot/compare/8.x-1.x...8.x-1.x-dev

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ It's possible to overwite the Cookiebot Domain Group ID (CBID) in the
 $config['cookiebot.settings']['cookiebot_cbid'] = 'COOKIEBOT DOMAIN GROUP ID';
 ```
 
+## Link to edit the Cookie consent
+
+Once the user has set his cookie consent he has by default no link to
+review/edit his consent.
+
+Add a menu item (e.g. to the footer menu) to update the cookie consent. The path
+of the menu item should be `/cookiebot-renew`. It will be automatically
+rewritten to trigger the cookie consent popup.
+
+It's always possible to add a custom link to trigger opening the cookie consent
+popup:
+
+```html
+<a href="javascript:Cookiebot.renew()">Update cookie consent</a>
+```
+
 ## Create cookie declaration page
 
 This module adds a filter to replace a token within formatted text content by
@@ -121,37 +137,8 @@ without cookies:
 Open the `admin/config/media/video-embed-field` page and change the "Privacy
 mode" to "Enabled".
 
-### Overwite the video-embed-iframe template
-
-The `video-embed-iframe.html.twig` template needs to be overwritten to let
-Cookiebot know, by the `data-cookieconsent="necessary"` property, that these can
-be safely loaded.
-
-```html
-{#
-/**
- * @file
- * Display an iframe with alterable components.
- */
-#}
-<iframe{{ attributes }}{% if url is not empty %} src="{{ url }}{% if query is not empty %}?{{ query | url_encode }}{% endif %}{% if fragment is not empty %}#{{ fragment }}{% endif %}"{% endif %} data-cookieconsent="necessary"></iframe>
-```
-
-## Link to edit the Cookie consent
-
-Once the user has set his cookie consent he has by default no link to
-review/edit his consent.
-
-Add a menu item (e.g. to the footer menu) to update the cookie consent. The path
-of the menu item should be `/cookiebot-renew`. It will be automatically
-rewritten to trigger the cookie consent popup.
-
-It's always possible to add a custom link to trigger opening the cookie consent
-popup:
-
-```html
-<a href="javascript:Cookiebot.renew()">Update cookie consent</a>
-```
+This module will set the proper consent category to the video embed iframes so
+they will no longer be blocked.
 
 [Cookiebot]: https://www.cookiebot.com/
 [Cookiebot module]: https://www.drupal.org/project/cookiebot

--- a/dg_cookiebot.module
+++ b/dg_cookiebot.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Implemented hooks.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_video_embed_iframe().
+ *
+ * Adds the proper <code>data-cookieconsent</code> attribute to the
+ * video_embed_iframe template when privacy option is enabled.
+ */
+function dg_cookiebot_preprocess_video_embed_iframe(&$variables): void {
+  $config = \Drupal::configFactory()->get('video_embed_field.settings');
+  if ($config->get('privacy_mode') !== 'enabled') {
+    return;
+  }
+
+  /** @var \Drupal\Core\Template\Attribute $attributes */
+  $attributes = &$variables['attributes'];
+  $attributes->setAttribute('data-cookieconsent', 'necessary');
+}


### PR DESCRIPTION
Services like Youtube and Vimeo provide by default iframes that track
the users with cookies. They provide a no-cookie domain but that is not
wat is used by default.

To avoid loading this iframes and the cookies that come with them,
Cookiebot removes the iframe content until the visitor has allowed
marketing cookies.

This fix adds the proper iframe consent category to video_embed_fields
if privacy is enabled.